### PR TITLE
chore: update dependencies and version bump to 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mastra-governed-rag",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mastra-governed-rag",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
                 "@ai-sdk/google": "^2.0.17",
@@ -162,7 +162,7 @@
                 "vitest": "^3.2.4"
             },
             "engines": {
-                "node": ">=22.20.0"
+                "node": ">=20.19.5"
             }
         },
         "node_modules/@a2a-js/sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
     "name": "mastra-governed-rag",
-    "version": "1.0.0",
+    "version": "1.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mastra-governed-rag",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "license": "MIT",
             "dependencies": {
                 "@ai-sdk/google": "^2.0.17",
                 "@ai-sdk/google-vertex": "^3.0.34",
-                "@ai-sdk/openai": "^2.0.42",
+                "@ai-sdk/openai": "^2.0.44",
                 "@dotenvx/dotenvx": "^1.51.0",
                 "@hookform/resolvers": "^5.2.2",
+                "@hugeicons/react": "^1.1.1",
                 "@mastra/auth": "^0.1.3",
                 "@mastra/auth-supabase": "^0.10.6",
                 "@mastra/client-js": "^0.15.0",
@@ -84,16 +85,16 @@
                 "input-otp": "^1.4.2",
                 "jiti": "^2.6.1",
                 "jose": "^6.1.0",
-                "jsdom": "^26.1.0",
-                "lucide-react": "^0.544.0",
-                "marked": "^16.3.0",
+                "jsdom": "^27.0.0",
+                "lucide-react": "^0.545.0",
+                "marked": "^16.4.0",
                 "motion": "^12.23.22",
                 "motion-plus-react": "^1.5.4",
                 "next": "^15.5.4",
                 "next-mdx-remote": "^5.0.0",
                 "next-sitemap": "^4.2.3",
                 "next-themes": "^0.4.6",
-                "playwright": "^1.55.1",
+                "playwright": "^1.56.0",
                 "postcss": "^8.5.6",
                 "react": "^19.2.0",
                 "react-countup": "^6.5.3",
@@ -105,7 +106,7 @@
                 "react-router": "^7.9.3",
                 "react-router-dom": "^7.9.3",
                 "reactflow": "^11.11.4",
-                "recharts": "^2.15.4",
+                "recharts": "^3.2.1",
                 "rehype": "^13.0.2",
                 "rehype-autolink-headings": "^7.1.0",
                 "rehype-dom-parse": "^5.0.2",
@@ -132,20 +133,19 @@
                 "tsparticles-confetti": "^2.12.0",
                 "uuid": "^13.0.0",
                 "vaul": "^1.1.2",
-                "zod": "^4.1.11"
+                "zod": "^4.1.12"
             },
             "devDependencies": {
                 "@tailwindcss/postcss": "^4.1.14",
                 "@testing-library/jest-dom": "^6.9.1",
                 "@testing-library/react": "^16.3.0",
-                "@types/jsdom": "^21.1.7",
-                "@types/node": "^24.6.2",
-                "@types/react": "^19.2.0",
-                "@types/react-dom": "^19.2.0",
+                "@types/jsdom": "^27.0.0",
+                "@types/node": "^24.7.0",
+                "@types/react": "^19.2.2",
+                "@types/react-dom": "^19.2.1",
                 "@types/react-router": "^5.1.20",
-                "@types/uuid": "^10.0.0",
-                "@typescript-eslint/eslint-plugin": "^8.45.0",
-                "@typescript-eslint/parser": "^8.45.0",
+                "@typescript-eslint/eslint-plugin": "^8.46.0",
+                "@typescript-eslint/parser": "^8.46.0",
                 "@vitest/coverage-v8": "^3.2.4",
                 "concurrently": "^9.2.1",
                 "dotenv-cli": "^10.0.0",
@@ -162,7 +162,7 @@
                 "vitest": "^3.2.4"
             },
             "engines": {
-                "node": ">=20.9.0"
+                "node": ">=22.20.0"
             }
         },
         "node_modules/@a2a-js/sdk": {
@@ -350,9 +350,9 @@
             }
         },
         "node_modules/@ai-sdk/openai": {
-            "version": "2.0.42",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.42.tgz",
-            "integrity": "sha512-9mM6QS8k0ooH9qMC27nlrYLQmNDnO6Rk0JTmFo/yUxpABEWOcvQhMWNHbp9lFL6Ty5vkdINrujhsAQfWuEleOg==",
+            "version": "2.0.44",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.44.tgz",
+            "integrity": "sha512-caK9v5YbBd38mjPmjBP5LSWiWhmHgK9mPwc7dE/3ED3c+SypH6/QWimGDA1oSsxDEdXgVCO9ORUVV+Uphzjf8Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ai-sdk/provider": "2.0.0",
@@ -792,17 +792,54 @@
             }
         },
         "node_modules/@asamuzakjp/css-color": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-            "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.5.tgz",
+            "integrity": "sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==",
             "license": "MIT",
             "dependencies": {
-                "@csstools/css-calc": "^2.1.3",
-                "@csstools/css-color-parser": "^3.0.9",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "lru-cache": "^10.4.3"
+                "@csstools/css-calc": "^2.1.4",
+                "@csstools/css-color-parser": "^3.1.0",
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4",
+                "lru-cache": "^11.2.1"
             }
+        },
+        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+            "version": "11.2.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+            "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+            "license": "ISC",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "6.6.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.6.1.tgz",
+            "integrity": "sha512-8QT9pokVe1fUt1C8IrJketaeFOdRfTOS96DL3EBjE8CRZm3eHnwMlQe2NPoOSEYPwJ5Q25uYoX1+m9044l3ysQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.1.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.2.2"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+            "version": "11.2.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+            "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+            "license": "ISC",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.27.1",
@@ -834,6 +871,7 @@
             "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
@@ -1238,6 +1276,7 @@
             "version": "7.28.4",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
             "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -1709,6 +1748,30 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@crawlee/jsdom/node_modules/@asamuzakjp/css-color": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+            "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/css-calc": "^2.1.3",
+                "@csstools/css-color-parser": "^3.0.9",
+                "@csstools/css-parser-algorithms": "^3.0.4",
+                "@csstools/css-tokenizer": "^3.0.3",
+                "lru-cache": "^10.4.3"
+            }
+        },
+        "node_modules/@crawlee/jsdom/node_modules/@types/jsdom": {
+            "version": "21.1.7",
+            "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+            "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/tough-cookie": "*",
+                "parse5": "^7.0.0"
+            }
+        },
         "node_modules/@crawlee/jsdom/node_modules/cheerio": {
             "version": "1.0.0-rc.12",
             "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
@@ -1730,6 +1793,32 @@
                 "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
             }
         },
+        "node_modules/@crawlee/jsdom/node_modules/cssstyle": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+            "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^3.2.0",
+                "rrweb-cssom": "^0.8.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@crawlee/jsdom/node_modules/data-urls": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@crawlee/jsdom/node_modules/htmlparser2": {
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -1747,6 +1836,109 @@
                 "domhandler": "^5.0.3",
                 "domutils": "^3.0.1",
                 "entities": "^4.4.0"
+            }
+        },
+        "node_modules/@crawlee/jsdom/node_modules/jsdom": {
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+            "license": "MIT",
+            "dependencies": {
+                "cssstyle": "^4.2.1",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.5.0",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "nwsapi": "^2.2.16",
+                "parse5": "^7.2.1",
+                "rrweb-cssom": "^0.8.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^5.1.1",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.1.1",
+                "ws": "^8.18.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@crawlee/jsdom/node_modules/tldts": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+            "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^6.1.86"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/@crawlee/jsdom/node_modules/tldts-core": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+            "license": "MIT"
+        },
+        "node_modules/@crawlee/jsdom/node_modules/tough-cookie": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+            "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^6.1.32"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@crawlee/jsdom/node_modules/tr46": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@crawlee/jsdom/node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@crawlee/jsdom/node_modules/whatwg-url": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "^5.1.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@crawlee/linkedom": {
@@ -2160,11 +2352,34 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
             "peerDependencies": {
                 "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+            "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4"
             }
         },
         "node_modules/@csstools/css-tokenizer": {
@@ -2182,6 +2397,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -3055,6 +3271,7 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
             "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@floating-ui/core": "^1.7.3",
                 "@floating-ui/utils": "^0.2.10"
@@ -3673,18 +3890,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/@hono/zod-validator": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.4.3.tgz",
-            "integrity": "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "peerDependencies": {
-                "hono": ">=3.9.0",
-                "zod": "^3.19.1"
-            }
-        },
         "node_modules/@hookform/resolvers": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
@@ -3695,6 +3900,15 @@
             },
             "peerDependencies": {
                 "react-hook-form": "^7.55.0"
+            }
+        },
+        "node_modules/@hugeicons/react": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@hugeicons/react/-/react-1.1.1.tgz",
+            "integrity": "sha512-BAbFVtx0XZ/yF2poPLFn0N9Ji6ebV/MpI5+WRqooFp3smQDwpL+72m+BBs4KAM5djgWUpg12weyc5SJtTsOwsw==",
+            "license": "SEE LICENSE IN LICENSE.md",
+            "peerDependencies": {
+                "react": ">=16.0.0"
             }
         },
         "node_modules/@humanfs/core": {
@@ -4824,6 +5038,7 @@
             "resolved": "https://registry.npmjs.org/@mastra/core/-/core-0.20.0.tgz",
             "integrity": "sha512-zFGnUUTJmJSaWaTnPxpW0GB6iFQyFTY2Iq4towAv8mhtDqiZYSgLi630BPQ3Atj+q5bX1xSHFFKUaOQA3fkikA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@a2a-js/sdk": "~0.2.4",
                 "@ai-sdk/provider": "^1.1.3",
@@ -5334,6 +5549,7 @@
             "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
             "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdx": "^2.0.0"
             },
@@ -5360,6 +5576,7 @@
             "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.18.0.tgz",
             "integrity": "sha512-JvKyB6YwS3quM+88JPR0axeRgvdDu3Pv6mdZUy+w4qVkCzGgumb9bXG/TmtDRQv+671yaofVfXSQmFLlWU5qPQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.6",
                 "content-type": "^1.0.5",
@@ -5779,6 +5996,7 @@
             "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
             "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^14.21.3 || >=16"
             },
@@ -5876,6 +6094,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
             "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -5972,6 +6191,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
             "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
@@ -7656,6 +7876,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
             "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.1.0",
                 "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -7720,6 +7941,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
             "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.1.0",
                 "@opentelemetry/resources": "2.1.0"
@@ -7865,6 +8087,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
             "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.1.0",
                 "@opentelemetry/resources": "2.1.0",
@@ -9677,6 +9900,7 @@
             "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.8.2.tgz",
             "integrity": "sha512-WtMScno3+eBpTac1Uav2zugXEoXqaU23YznwvFgkPwBQVwEHTDgOG7uEAObtZ/Nyn8SmAMbqkEubJaMOvnqdsQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cluster-key-slot": "1.1.2"
             },
@@ -9718,6 +9942,32 @@
             },
             "peerDependencies": {
                 "@redis/client": "^5.8.2"
+            }
+        },
+        "node_modules/@reduxjs/toolkit": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
+            "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/utils": "^0.3.0",
+                "immer": "^10.0.3",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@remirror/core-constants": {
@@ -10984,7 +11234,6 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -11005,7 +11254,6 @@
             "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "dequal": "^2.0.3"
             }
@@ -11208,6 +11456,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.26.1.tgz",
             "integrity": "sha512-fymyd/XZvYiHjBoLt1gxs024xP/LY26d43R1vluYq7AHBL/7DE3ywzy+1GEsGyAv5Je2L0KBhNIR/izbq3Kaqg==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -11473,6 +11722,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.26.1.tgz",
             "integrity": "sha512-8aF+mY/vSHbGFqyG663ds84b+vca5Lge3tHdTMTKazxCnhXR9dn2oQJMnZ78YZvdRbkPkMJJHti9h3K7u2UQvw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prosemirror-changeset": "^2.3.0",
                 "prosemirror-collab": "^1.3.1",
@@ -11582,7 +11832,8 @@
                 }
             ],
             "hasInstallScript": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@tsparticles/interaction-external-attract": {
             "version": "3.9.1",
@@ -12036,8 +12287,7 @@
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/aws-lambda": {
             "version": "8.10.152",
@@ -12469,9 +12719,10 @@
             "license": "MIT"
         },
         "node_modules/@types/jsdom": {
-            "version": "21.1.7",
-            "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
-            "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+            "version": "27.0.0",
+            "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-27.0.0.tgz",
+            "integrity": "sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
@@ -12483,7 +12734,8 @@
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/json5": {
             "version": "0.0.29",
@@ -12591,12 +12843,12 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "24.6.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
-            "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
+            "version": "24.7.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.0.tgz",
+            "integrity": "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.13.0"
+                "undici-types": "~7.14.0"
             }
         },
         "node_modules/@types/node-fetch": {
@@ -12663,19 +12915,21 @@
             "license": "MIT"
         },
         "node_modules/@types/react": {
-            "version": "19.2.0",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
-            "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
+            "version": "19.2.2",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
+            "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.0.2"
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "19.2.0",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.0.tgz",
-            "integrity": "sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg==",
+            "version": "19.2.1",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.1.tgz",
+            "integrity": "sha512-/EEvYBdT3BflCWvTMO7YkYBHVE9Ci6XdqZciZANQgKpaiDRGOLIlRo91jbTNRQjgPFWVaRxcYc0luVNFitz57A==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -12797,13 +13051,6 @@
             "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
             "license": "MIT"
         },
-        "node_modules/@types/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/ws": {
             "version": "8.18.1",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -12824,17 +13071,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.45.0.tgz",
-            "integrity": "sha512-HC3y9CVuevvWCl/oyZuI47dOeDF9ztdMEfMH8/DW/Mhwa9cCLnK1oD7JoTVGW/u7kFzNZUKUoyJEqkaJh5y3Wg==",
+            "version": "8.46.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.0.tgz",
+            "integrity": "sha512-hA8gxBq4ukonVXPy0OKhiaUh/68D0E88GSmtC1iAEnGaieuDi38LhS7jdCHRLi6ErJBNDGCzvh5EnzdPwUc0DA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.45.0",
-                "@typescript-eslint/type-utils": "8.45.0",
-                "@typescript-eslint/utils": "8.45.0",
-                "@typescript-eslint/visitor-keys": "8.45.0",
+                "@typescript-eslint/scope-manager": "8.46.0",
+                "@typescript-eslint/type-utils": "8.46.0",
+                "@typescript-eslint/utils": "8.46.0",
+                "@typescript-eslint/visitor-keys": "8.46.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
@@ -12848,22 +13095,23 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.45.0",
+                "@typescript-eslint/parser": "^8.46.0",
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.45.0.tgz",
-            "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
+            "version": "8.46.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.0.tgz",
+            "integrity": "sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.45.0",
-                "@typescript-eslint/types": "8.45.0",
-                "@typescript-eslint/typescript-estree": "8.45.0",
-                "@typescript-eslint/visitor-keys": "8.45.0",
+                "@typescript-eslint/scope-manager": "8.46.0",
+                "@typescript-eslint/types": "8.46.0",
+                "@typescript-eslint/typescript-estree": "8.46.0",
+                "@typescript-eslint/visitor-keys": "8.46.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -12879,14 +13127,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.45.0.tgz",
-            "integrity": "sha512-3pcVHwMG/iA8afdGLMuTibGR7pDsn9RjDev6CCB+naRsSYs2pns5QbinF4Xqw6YC/Sj3lMrm/Im0eMfaa61WUg==",
+            "version": "8.46.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.0.tgz",
+            "integrity": "sha512-OEhec0mH+U5Je2NZOeK1AbVCdm0ChyapAyTeXVIYTPXDJ3F07+cu87PPXcGoYqZ7M9YJVvFnfpGg1UmCIqM+QQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.45.0",
-                "@typescript-eslint/types": "^8.45.0",
+                "@typescript-eslint/tsconfig-utils": "^8.46.0",
+                "@typescript-eslint/types": "^8.46.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -12901,14 +13149,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.45.0.tgz",
-            "integrity": "sha512-clmm8XSNj/1dGvJeO6VGH7EUSeA0FMs+5au/u3lrA3KfG8iJ4u8ym9/j2tTEoacAffdW1TVUzXO30W1JTJS7dA==",
+            "version": "8.46.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.0.tgz",
+            "integrity": "sha512-lWETPa9XGcBes4jqAMYD9fW0j4n6hrPtTJwWDmtqgFO/4HF4jmdH/Q6wggTw5qIT5TXjKzbt7GsZUBnWoO3dqw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.45.0",
-                "@typescript-eslint/visitor-keys": "8.45.0"
+                "@typescript-eslint/types": "8.46.0",
+                "@typescript-eslint/visitor-keys": "8.46.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12919,9 +13167,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.45.0.tgz",
-            "integrity": "sha512-aFdr+c37sc+jqNMGhH+ajxPXwjv9UtFZk79k8pLoJ6p4y0snmYpPA52GuWHgt2ZF4gRRW6odsEj41uZLojDt5w==",
+            "version": "8.46.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.0.tgz",
+            "integrity": "sha512-WrYXKGAHY836/N7zoK/kzi6p8tXFhasHh8ocFL9VZSAkvH956gfeRfcnhs3xzRy8qQ/dq3q44v1jvQieMFg2cw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12936,15 +13184,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.45.0.tgz",
-            "integrity": "sha512-bpjepLlHceKgyMEPglAeULX1vixJDgaKocp0RVJ5u4wLJIMNuKtUXIczpJCPcn2waII0yuvks/5m5/h3ZQKs0A==",
+            "version": "8.46.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.0.tgz",
+            "integrity": "sha512-hy+lvYV1lZpVs2jRaEYvgCblZxUoJiPyCemwbQZ+NGulWkQRy0HRPYAoef/CNSzaLt+MLvMptZsHXHlkEilaeg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.45.0",
-                "@typescript-eslint/typescript-estree": "8.45.0",
-                "@typescript-eslint/utils": "8.45.0",
+                "@typescript-eslint/types": "8.46.0",
+                "@typescript-eslint/typescript-estree": "8.46.0",
+                "@typescript-eslint/utils": "8.46.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.1.0"
             },
@@ -12961,9 +13209,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.45.0.tgz",
-            "integrity": "sha512-WugXLuOIq67BMgQInIxxnsSyRLFxdkJEJu8r4ngLR56q/4Q5LrbfkFRH27vMTjxEK8Pyz7QfzuZe/G15qQnVRA==",
+            "version": "8.46.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.0.tgz",
+            "integrity": "sha512-bHGGJyVjSE4dJJIO5yyEWt/cHyNwga/zXGJbJJ8TiO01aVREK6gCTu3L+5wrkb1FbDkQ+TKjMNe9R/QQQP9+rA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12975,16 +13223,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.45.0.tgz",
-            "integrity": "sha512-GfE1NfVbLam6XQ0LcERKwdTTPlLvHvXXhOeUGC1OXi4eQBoyy1iVsW+uzJ/J9jtCz6/7GCQ9MtrQ0fml/jWCnA==",
+            "version": "8.46.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.0.tgz",
+            "integrity": "sha512-ekDCUfVpAKWJbRfm8T1YRrCot1KFxZn21oV76v5Fj4tr7ELyk84OS+ouvYdcDAwZL89WpEkEj2DKQ+qg//+ucg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.45.0",
-                "@typescript-eslint/tsconfig-utils": "8.45.0",
-                "@typescript-eslint/types": "8.45.0",
-                "@typescript-eslint/visitor-keys": "8.45.0",
+                "@typescript-eslint/project-service": "8.46.0",
+                "@typescript-eslint/tsconfig-utils": "8.46.0",
+                "@typescript-eslint/types": "8.46.0",
+                "@typescript-eslint/visitor-keys": "8.46.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -13004,16 +13252,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.45.0.tgz",
-            "integrity": "sha512-bxi1ht+tLYg4+XV2knz/F7RVhU0k6VrSMc9sb8DQ6fyCTrGQLHfo7lDtN0QJjZjKkLA2ThrKuCdHEvLReqtIGg==",
+            "version": "8.46.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.0.tgz",
+            "integrity": "sha512-nD6yGWPj1xiOm4Gk0k6hLSZz2XkNXhuYmyIrOWcHoPuAhjT9i5bAG+xbWPgFeNR8HPHHtpNKdYUXJl/D3x7f5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.45.0",
-                "@typescript-eslint/types": "8.45.0",
-                "@typescript-eslint/typescript-estree": "8.45.0"
+                "@typescript-eslint/scope-manager": "8.46.0",
+                "@typescript-eslint/types": "8.46.0",
+                "@typescript-eslint/typescript-estree": "8.46.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -13028,13 +13276,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.45.0.tgz",
-            "integrity": "sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==",
+            "version": "8.46.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.0.tgz",
+            "integrity": "sha512-FrvMpAK+hTbFy7vH5j1+tMYHMSKLE6RzluFJlkFNKD0p9YsUT75JlBSmr5so3QRzvMwU5/bIEdeNrxm8du8l3Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.45.0",
+                "@typescript-eslint/types": "8.46.0",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -13562,6 +13810,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -13622,6 +13871,7 @@
             "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.60.tgz",
             "integrity": "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@ai-sdk/gateway": "1.0.33",
                 "@ai-sdk/provider": "2.0.0",
@@ -14282,6 +14532,15 @@
                 "baseline-browser-mapping": "dist/cli.js"
             }
         },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
+            }
+        },
         "node_modules/big.js": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-7.0.1.tgz",
@@ -14381,6 +14640,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.3",
                 "caniuse-lite": "^1.0.30001741",
@@ -14648,6 +14908,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.26.1.tgz",
             "integrity": "sha512-fymyd/XZvYiHjBoLt1gxs024xP/LY26d43R1vluYq7AHBL/7DE3ywzy+1GEsGyAv5Je2L0KBhNIR/izbq3Kaqg==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -14737,6 +14998,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.26.1.tgz",
             "integrity": "sha512-8aF+mY/vSHbGFqyG663ds84b+vca5Lge3tHdTMTKazxCnhXR9dn2oQJMnZ78YZvdRbkPkMJJHti9h3K7u2UQvw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prosemirror-changeset": "^2.3.0",
                 "prosemirror-collab": "^1.3.1",
@@ -14790,6 +15052,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-2.26.1.tgz",
             "integrity": "sha512-iNWJdQN7h01keNoVwyCsdI7ZX11YkrexZjCnutWK17Dd72s3NYVTmQXu7saftwddT4nDdlczNxAFosrt0zMhcg==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -15038,6 +15301,7 @@
             "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
             "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@chevrotain/cst-dts-gen": "11.0.3",
                 "@chevrotain/gast": "11.0.3",
@@ -15519,6 +15783,19 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
+        "node_modules/css-tree": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+            "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.12.2",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
         "node_modules/css-what": {
             "version": "6.2.2",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -15556,16 +15833,17 @@
             "license": "MIT"
         },
         "node_modules/cssstyle": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
-            "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.1.tgz",
+            "integrity": "sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==",
             "license": "MIT",
             "dependencies": {
-                "@asamuzakjp/css-color": "^3.2.0",
-                "rrweb-cssom": "^0.8.0"
+                "@asamuzakjp/css-color": "^4.0.3",
+                "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+                "css-tree": "^3.1.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/csstype": {
@@ -15585,6 +15863,7 @@
             "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
             "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -15994,6 +16273,7 @@
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -16105,16 +16385,16 @@
             }
         },
         "node_modules/data-urls": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+            "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
             "license": "MIT",
             "dependencies": {
                 "whatwg-mimetype": "^4.0.0",
-                "whatwg-url": "^14.0.0"
+                "whatwg-url": "^15.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/data-view-buffer": {
@@ -16521,18 +16801,7 @@
             "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
             "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/dom-helpers": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-            "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.8.7",
-                "csstype": "^3.0.2"
-            }
+            "license": "MIT"
         },
         "node_modules/dom-serializer": {
             "version": "2.0.0",
@@ -16759,7 +17028,8 @@
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
             "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/embla-carousel-react": {
             "version": "8.6.0",
@@ -17036,6 +17306,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/es-toolkit": {
+            "version": "1.39.10",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
+            "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks"
+            ]
+        },
         "node_modules/esast-util-from-estree": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
@@ -17075,6 +17355,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -17143,6 +17424,7 @@
             "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -17332,6 +17614,7 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -17867,9 +18150,9 @@
             }
         },
         "node_modules/eventemitter3": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
             "license": "MIT"
         },
         "node_modules/eventid": {
@@ -18224,15 +18507,6 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "license": "MIT"
         },
-        "node_modules/fast-equals": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
-            "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/fast-glob": {
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -18278,15 +18552,6 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "license": "MIT"
-        },
-        "node_modules/fast-redact": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-            "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/fast-safe-stringify": {
             "version": "2.1.1",
@@ -20497,7 +20762,6 @@
             "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
             "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
             "license": "MIT",
-            "optional": true,
             "peer": true,
             "funding": {
                 "type": "opencollective",
@@ -21468,34 +21732,35 @@
             }
         },
         "node_modules/jsdom": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+            "version": "27.0.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+            "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "cssstyle": "^4.2.1",
-                "data-urls": "^5.0.0",
+                "@asamuzakjp/dom-selector": "^6.5.4",
+                "cssstyle": "^5.3.0",
+                "data-urls": "^6.0.0",
                 "decimal.js": "^10.5.0",
                 "html-encoding-sniffer": "^4.0.0",
                 "http-proxy-agent": "^7.0.2",
                 "https-proxy-agent": "^7.0.6",
                 "is-potential-custom-element-name": "^1.0.1",
-                "nwsapi": "^2.2.16",
-                "parse5": "^7.2.1",
+                "parse5": "^7.3.0",
                 "rrweb-cssom": "^0.8.0",
                 "saxes": "^6.0.0",
                 "symbol-tree": "^3.2.4",
-                "tough-cookie": "^5.1.1",
+                "tough-cookie": "^6.0.0",
                 "w3c-xmlserializer": "^5.0.0",
-                "webidl-conversions": "^7.0.0",
+                "webidl-conversions": "^8.0.0",
                 "whatwg-encoding": "^3.1.1",
                 "whatwg-mimetype": "^4.0.0",
-                "whatwg-url": "^14.1.1",
-                "ws": "^8.18.0",
+                "whatwg-url": "^15.0.0",
+                "ws": "^8.18.2",
                 "xml-name-validator": "^5.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "peerDependencies": {
                 "canvas": "^3.0.0"
@@ -21504,36 +21769,6 @@
                 "canvas": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/jsdom/node_modules/tldts": {
-            "version": "6.1.86",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-            "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
-            "license": "MIT",
-            "dependencies": {
-                "tldts-core": "^6.1.86"
-            },
-            "bin": {
-                "tldts": "bin/cli.js"
-            }
-        },
-        "node_modules/jsdom/node_modules/tldts-core": {
-            "version": "6.1.86",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-            "license": "MIT"
-        },
-        "node_modules/jsdom/node_modules/tough-cookie": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-            "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tldts": "^6.1.32"
-            },
-            "engines": {
-                "node": ">=16"
             }
         },
         "node_modules/jsesc": {
@@ -22415,6 +22650,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
@@ -22477,9 +22713,9 @@
             "license": "ISC"
         },
         "node_modules/lucide-react": {
-            "version": "0.544.0",
-            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
-            "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+            "version": "0.545.0",
+            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.545.0.tgz",
+            "integrity": "sha512-7r1/yUuflQDSt4f1bpn5ZAocyIxcTyVyBBChSVtBKn5M+392cPmI5YJMWOJKk/HUWGm5wg83chlAZtCcGbEZtw==",
             "license": "ISC",
             "peerDependencies": {
                 "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -22491,7 +22727,6 @@
             "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -22579,9 +22814,9 @@
             }
         },
         "node_modules/marked": {
-            "version": "16.3.0",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-16.3.0.tgz",
-            "integrity": "sha512-K3UxuKu6l6bmA5FUwYho8CfJBlsUWAooKtdGgMcERSpF7gcBUrCGsLH7wDaaNOzwq18JzSUDyoEb/YsrqMac3w==",
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.0.tgz",
+            "integrity": "sha512-CTPAcRBq57cn3R8n3hwc2REddc28hjR7RzDXQ+lXLmMJYqn20BaI2cGw6QjgZGIgVfp2Wdfw4aMzgNteQ6qJgQ==",
             "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
@@ -22993,6 +23228,12 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.12.2",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+            "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+            "license": "CC0-1.0"
         },
         "node_modules/mdurl": {
             "version": "2.0.0",
@@ -25132,6 +25373,7 @@
             "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
             "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pg-connection-string": "^2.9.1",
                 "pg-pool": "^3.10.1",
@@ -25172,7 +25414,6 @@
             "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.15.3.tgz",
             "integrity": "sha512-eHw63TsiGtFEfAd7tOTZ+TLy+i/2ePKS20H84qCQ+aQ60pve05Okon9tKMC+YN3j6XyeFoHnaim7Lt9WVafQsA==",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "pg": "^8"
             }
@@ -25285,13 +25526,12 @@
             }
         },
         "node_modules/pino": {
-            "version": "9.10.0",
-            "resolved": "https://registry.npmjs.org/pino/-/pino-9.10.0.tgz",
-            "integrity": "sha512-VOFxoNnxICtxaN8S3E73pR66c5MTFC+rwRcNRyHV/bV/c90dXvJqMfjkeRFsGBDXmlUN3LccJQPqGIufnaJePA==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+            "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
             "license": "MIT",
             "dependencies": {
                 "atomic-sleep": "^1.0.0",
-                "fast-redact": "^3.1.1",
                 "on-exit-leak-free": "^2.1.0",
                 "pino-abstract-transport": "^2.0.0",
                 "pino-std-serializers": "^7.0.0",
@@ -25299,6 +25539,7 @@
                 "quick-format-unescaped": "^4.0.3",
                 "real-require": "^0.2.0",
                 "safe-stable-stringify": "^2.3.1",
+                "slow-redact": "^0.3.0",
                 "sonic-boom": "^4.0.1",
                 "thread-stream": "^3.0.0"
             },
@@ -25442,11 +25683,13 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.55.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
-            "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+            "version": "1.56.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
+            "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+            "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
-                "playwright-core": "1.55.1"
+                "playwright-core": "1.56.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -25459,9 +25702,10 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.55.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
-            "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+            "version": "1.56.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
+            "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+            "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
             },
@@ -25528,6 +25772,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -25658,7 +25903,6 @@
             "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -25674,7 +25918,6 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -25687,8 +25930,7 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/pretty-ms": {
             "version": "9.3.0",
@@ -25731,6 +25973,7 @@
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.4.0",
@@ -25877,6 +26120,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.3.tgz",
             "integrity": "sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "orderedmap": "^2.0.0"
             }
@@ -25906,6 +26150,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
             "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.0.0",
                 "prosemirror-transform": "^1.0.0",
@@ -25966,6 +26211,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.0.tgz",
             "integrity": "sha512-FatMIIl0vRHMcNc3sPy3cMw5MMyWuO1nWQxqvYpJvXAruucGvmQ2tyyjT2/Lbok77T9a/qZqBVCq4sj43V2ihw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.20.0",
                 "prosemirror-state": "^1.0.0",
@@ -26204,6 +26450,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
             "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -26246,6 +26493,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
             "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -26258,6 +26506,7 @@
             "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.64.0.tgz",
             "integrity": "sha512-fnN+vvTiMLnRqKNTVhDysdrUay0kUUAymQnFIznmgDvapjveUWOOPqMNzPg+A+0yf9DuE2h6xzBjN1s+Qx8wcg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.0.0"
             },
@@ -26273,7 +26522,8 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/react-markdown": {
             "version": "10.1.0",
@@ -26300,6 +26550,30 @@
             "peerDependencies": {
                 "@types/react": ">=18",
                 "react": ">=18"
+            }
+        },
+        "node_modules/react-redux": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+            "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25 || ^19",
+                "react": "^18.0 || ^19",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
             }
         },
         "node_modules/react-refresh": {
@@ -26416,21 +26690,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/react-smooth": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
-            "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
-            "license": "MIT",
-            "dependencies": {
-                "fast-equals": "^5.0.1",
-                "prop-types": "^15.8.1",
-                "react-transition-group": "^4.4.5"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
-        },
         "node_modules/react-style-singleton": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -26451,22 +26710,6 @@
                 "@types/react": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/react-transition-group": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-            "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@babel/runtime": "^7.5.5",
-                "dom-helpers": "^5.0.1",
-                "loose-envify": "^1.4.0",
-                "prop-types": "^15.6.2"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0",
-                "react-dom": ">=16.6.0"
             }
         },
         "node_modules/reactflow": {
@@ -26511,42 +26754,31 @@
             }
         },
         "node_modules/recharts": {
-            "version": "2.15.4",
-            "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
-            "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.1.tgz",
+            "integrity": "sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==",
             "license": "MIT",
             "dependencies": {
-                "clsx": "^2.0.0",
-                "eventemitter3": "^4.0.1",
-                "lodash": "^4.17.21",
-                "react-is": "^18.3.1",
-                "react-smooth": "^4.0.4",
-                "recharts-scale": "^0.4.4",
-                "tiny-invariant": "^1.3.1",
-                "victory-vendor": "^36.6.8"
+                "@reduxjs/toolkit": "1.x.x || 2.x.x",
+                "clsx": "^2.1.1",
+                "decimal.js-light": "^2.5.1",
+                "es-toolkit": "^1.39.3",
+                "eventemitter3": "^5.0.1",
+                "immer": "^10.1.1",
+                "react-redux": "8.x.x || 9.x.x",
+                "reselect": "5.1.1",
+                "tiny-invariant": "^1.3.3",
+                "use-sync-external-store": "^1.2.2",
+                "victory-vendor": "^37.0.2"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             },
             "peerDependencies": {
-                "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
-        },
-        "node_modules/recharts-scale": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
-            "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
-            "license": "MIT",
-            "dependencies": {
-                "decimal.js-light": "^2.4.1"
-            }
-        },
-        "node_modules/recharts/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "license": "MIT"
         },
         "node_modules/recma-build-jsx": {
             "version": "1.0.0",
@@ -26643,6 +26875,22 @@
             },
             "engines": {
                 "node": ">= 18"
+            }
+        },
+        "node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "redux": "^5.0.0"
             }
         },
         "node_modules/reflect.getprototypeof": {
@@ -27138,6 +27386,12 @@
                 "node": ">=8.6.0"
             }
         },
+        "node_modules/reselect": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+            "license": "MIT"
+        },
         "node_modules/resolve": {
             "version": "1.22.10",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -27364,6 +27618,7 @@
             "integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -28049,6 +28304,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/slow-redact": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.1.tgz",
+            "integrity": "sha512-NvFvl1GuLZNW4U046Tfi8b26zXo8aBzgCAS2f7yVJR/fArN93mOqSA99cB9uITm92ajSz01bsu1K7SCVVjIMpQ==",
+            "license": "MIT"
+        },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -28669,7 +28930,8 @@
             "version": "4.1.14",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
             "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tailwindcss-motion": {
             "version": "1.1.1",
@@ -29056,15 +29318,15 @@
             }
         },
         "node_modules/tr46": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
             "license": "MIT",
             "dependencies": {
                 "punycode": "^2.3.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/tree-kill": {
@@ -29623,6 +29885,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -29705,9 +29968,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
-            "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+            "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
             "license": "MIT"
         },
         "node_modules/unicorn-magic": {
@@ -30246,9 +30509,9 @@
             }
         },
         "node_modules/victory-vendor": {
-            "version": "36.9.2",
-            "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
-            "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+            "version": "37.3.6",
+            "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+            "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
             "license": "MIT AND ISC",
             "dependencies": {
                 "@types/d3-array": "^3.0.3",
@@ -30273,6 +30536,7 @@
             "integrity": "sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.5.0",
@@ -30371,6 +30635,7 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",
@@ -30534,12 +30799,12 @@
             }
         },
         "node_modules/webidl-conversions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+            "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
             "license": "BSD-2-Clause",
             "engines": {
-                "node": ">=12"
+                "node": ">=20"
             }
         },
         "node_modules/whatwg-encoding": {
@@ -30564,16 +30829,16 @@
             }
         },
         "node_modules/whatwg-url": {
-            "version": "14.2.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+            "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
             "license": "MIT",
             "dependencies": {
-                "tr46": "^5.1.0",
-                "webidl-conversions": "^7.0.0"
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/which": {
@@ -31107,10 +31372,11 @@
             }
         },
         "node_modules/zod": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
-            "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+            "version": "4.1.12",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+            "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mastra-governed-rag",
-    "version": "1.0.0",
+    "version": "1.1.1",
     "description": "Secure, governed RAG template with role-based access control using Mastra",
     "main": "dist/index.js",
     "type": "module",
@@ -37,14 +37,15 @@
     },
     "license": "MIT",
     "engines": {
-        "node": ">=20.9.0"
+        "node": ">=22.20.0"
     },
     "dependencies": {
         "@ai-sdk/google": "^2.0.17",
         "@ai-sdk/google-vertex": "^3.0.34",
-        "@ai-sdk/openai": "^2.0.42",
+        "@ai-sdk/openai": "^2.0.44",
         "@dotenvx/dotenvx": "^1.51.0",
         "@hookform/resolvers": "^5.2.2",
+        "@hugeicons/react": "^1.1.1",
         "@mastra/auth": "^0.1.3",
         "@mastra/auth-supabase": "^0.10.6",
         "@mastra/client-js": "^0.15.0",
@@ -115,16 +116,16 @@
         "input-otp": "^1.4.2",
         "jiti": "^2.6.1",
         "jose": "^6.1.0",
-        "jsdom": "^26.1.0",
-        "lucide-react": "^0.544.0",
-        "marked": "^16.3.0",
+        "jsdom": "^27.0.0",
+        "lucide-react": "^0.545.0",
+        "marked": "^16.4.0",
         "motion": "^12.23.22",
         "motion-plus-react": "^1.5.4",
         "next": "^15.5.4",
         "next-mdx-remote": "^5.0.0",
         "next-sitemap": "^4.2.3",
         "next-themes": "^0.4.6",
-        "playwright": "^1.55.1",
+        "playwright": "^1.56.0",
         "postcss": "^8.5.6",
         "react": "^19.2.0",
         "react-countup": "^6.5.3",
@@ -136,7 +137,7 @@
         "react-router": "^7.9.3",
         "react-router-dom": "^7.9.3",
         "reactflow": "^11.11.4",
-        "recharts": "^2.15.4",
+        "recharts": "^3.2.1",
         "rehype": "^13.0.2",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-dom-parse": "^5.0.2",
@@ -163,20 +164,19 @@
         "tsparticles-confetti": "^2.12.0",
         "uuid": "^13.0.0",
         "vaul": "^1.1.2",
-        "zod": "^4.1.11"
+        "zod": "^4.1.12"
     },
     "devDependencies": {
         "@tailwindcss/postcss": "^4.1.14",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
-        "@types/jsdom": "^21.1.7",
-        "@types/node": "^24.6.2",
-        "@types/react": "^19.2.0",
-        "@types/react-dom": "^19.2.0",
+        "@types/jsdom": "^27.0.0",
+        "@types/node": "^24.7.0",
+        "@types/react": "^19.2.2",
+        "@types/react-dom": "^19.2.1",
         "@types/react-router": "^5.1.20",
-        "@types/uuid": "^10.0.0",
-        "@typescript-eslint/eslint-plugin": "^8.45.0",
-        "@typescript-eslint/parser": "^8.45.0",
+        "@typescript-eslint/eslint-plugin": "^8.46.0",
+        "@typescript-eslint/parser": "^8.46.0",
         "@vitest/coverage-v8": "^3.2.4",
         "concurrently": "^9.2.1",
         "dotenv-cli": "^10.0.0",
@@ -194,8 +194,9 @@
     },
     "overrides": {
         "jsondiffpatch": "0.7.3",
-        "zod": "^4.1.11",
+        "zod": "^4.1.12",
         "axios": "^1.12.2",
-        "lucide-react": "^0.544.0"
+        "lucide-react": "^0.545.0",
+        "pino": "^10.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mastra-governed-rag",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Secure, governed RAG template with role-based access control using Mastra",
     "main": "dist/index.js",
     "type": "module",
@@ -37,7 +37,7 @@
     },
     "license": "MIT",
     "engines": {
-        "node": ">=22.20.0"
+        "node": ">=20.19.5"
     },
     "dependencies": {
         "@ai-sdk/google": "^2.0.17",


### PR DESCRIPTION
- Bump version from 1.0.0 to 1.1.1
- Update Node.js engine requirement to >=22.20.0
- Upgrade @ai-sdk/openai from ^2.0.42 to ^2.0.44
- Add @hugeicons/react as a new dependency
- Upgrade jsdom from ^26.1.0 to ^27.0.0
- Upgrade lucide-react from ^0.544.0 to ^0.545.0
- Upgrade marked from ^16.3.0 to ^16.4.0
- Upgrade playwright from ^1.55.1 to ^1.56.0
- Upgrade recharts from ^2.15.4 to ^3.2.1
- Upgrade zod from ^4.1.11 to ^4.1.12
- Update devDependencies:
  - @types/jsdom from ^21.1.7 to ^27.0.0
  - @types/node from ^24.6.2 to ^24.7.0
  - @types/react from ^19.2.0 to ^19.2.2
  - @types/react-dom from ^19.2.0 to ^19.2.1
  - @typescript-eslint/eslint-plugin and parser from ^8.45.0 to ^8.46.0
- Add pino to overrides